### PR TITLE
Removed the upper bounds of the miencraft dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This is a [Fabric](https://fabricmc.net/) mod that lowers the permission of the 
 
 Check out [my blog post announcing this mod!](https://bd103.github.io/blog/2023-11-03-announcing-ticklowerperm)
 
+## Snapshot Support
+
+TickLowerPerm is only tested on the Minecraft versions specified in Modrinth and in the [release notes](https://github.com/BD103/TickLowerPerm/releases). You can run it on untested snapshot versions including and above 1.20.3, but things may break. You've been warned!
+
 ## Credits
 
 Thank you to @Linguardium for their [help with mixins](https://discord.com/channels/507304429255393322/807617700734042122/1168716370159079524).

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,7 +19,7 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.14.24",
-		"minecraft": ">=1.20.3-alpha.23.43.a <=1.20.4",
+		"minecraft": ">=1.20.3-alpha.23.43.a",
 		"java": ">=17"
 	}
 }


### PR DESCRIPTION
Hey, thanks for this mod, I was about to make it if it didn't exist already 😂 

One thing I've recently realised with my mods is that you can safely remove the upper bounds in the fabric mod json for the minecraft version.
What this does is allows people to test your mod(s) in upcoming snapshots without you having to create a specific build for the given version.

This way the mod loader won't stop people from using the mod even on a higher minecraft version. Especially in this case, it _should_ work with a bunch of upcoming versions.
All the work you need to do when there's a new MC version is to go into Modrinth and tell it that it also supports the new versions :)